### PR TITLE
remove unnecessary plist_options

### DIFF
--- a/Formula/appveyor-host-agent.rb
+++ b/Formula/appveyor-host-agent.rb
@@ -50,7 +50,7 @@ class AppveyorHostAgent < Formula
   end
 
 
-  plist_options :startup => false
+  #plist_options :startup => false
 
   def plist
     <<~EOS


### PR DESCRIPTION
It seems that this option is [unnecessary](https://github.com/orgs/Homebrew/discussions/4187) and because it is now [deprecated](https://rubydoc.brew.sh/Formula.html#plist_options-class_method) gives an error when trying to run the formula.